### PR TITLE
Reduce requirements to php 8.3

### DIFF
--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -13,7 +13,7 @@ jobs:
 
         strategy:
             matrix:
-                php_version: ["8.4"]
+                php_version: ["8.3"]
 
         name: PHPCSFixer with PHP ${{ matrix.php_version }}
         steps:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -13,7 +13,7 @@ jobs:
 
         strategy:
             matrix:
-                php_version: ["8.4", "8.5"]
+                php_version: ["8.3", "8.4", "8.5"]
 
         name: PHPStan with PHP ${{ matrix.php_version }}
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -14,11 +14,17 @@ jobs:
         strategy:
             matrix:
                 include:
+                    - php_version: "8.3"
+                      dependency_version: "--prefer-lowest"
+
                     - php_version: "8.4"
                       dependency_version: "--prefer-lowest"
 
                     - php_version: "8.5"
                       dependency_version: "--prefer-lowest"
+
+                    - php_version: "8.3"
+                      dependency_version: ""
 
                     - php_version: "8.4"
                       dependency_version: ""

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-return new PhpCsFixer\Config()
+return (new PhpCsFixer\Config())
     ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
     ->setRules([
         '@Symfony' => true,

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "dpop"
     ],
     "require": {
-        "php": "^8.4",
+        "php": "^8.3",
         "psr/clock": "^1.0",
         "spomky-labs/base64url": "^2.0"
     },

--- a/src/Encoder/DPoPTokenEncoderInterface.php
+++ b/src/Encoder/DPoPTokenEncoderInterface.php
@@ -7,7 +7,7 @@ use danielburger1337\OAuth2\DPoP\Model\JwkInterface;
 
 interface DPoPTokenEncoderInterface
 {
-    final public const string TYPE_HEADER_PARAMETER = 'dpop+jwt';
+    final public const TYPE_HEADER_PARAMETER = 'dpop+jwt';
 
     /**
      * Select the JWK used to sign a DPoP proof.

--- a/src/NonceFactory/WebTokenFrameworkNonceFactory.php
+++ b/src/NonceFactory/WebTokenFrameworkNonceFactory.php
@@ -20,7 +20,7 @@ use Psr\Clock\ClockInterface;
 
 class WebTokenFrameworkNonceFactory implements NonceFactoryInterface
 {
-    final public const string TYPE_PARAMETER = 'dpop+nonce';
+    final public const TYPE_PARAMETER = 'dpop+nonce';
 
     private readonly AlgorithmManager $algorithmManager;
     private readonly JWKSet $jwkSet;

--- a/src/NonceStorage/NullNonceStorage.php
+++ b/src/NonceStorage/NullNonceStorage.php
@@ -7,7 +7,7 @@ namespace danielburger1337\OAuth2\DPoP\NonceStorage;
  */
 final class NullNonceStorage implements NonceStorageInterface
 {
-    public function getCurrentNonce(string $key): null
+    public function getCurrentNonce(string $key): ?string
     {
         return null;
     }

--- a/src/Util.php
+++ b/src/Util.php
@@ -60,21 +60,20 @@ final class Util
                 ->withQuery(null)
                 ->withFragment(null)
                 ->toString();
-        } else {
-            if ($htu instanceof UriInterface) {
-                $htu = (string) $htu;
-            }
+        }
+        if ($htu instanceof UriInterface) {
+            $htu = (string) $htu;
+        }
 
-            // This parser is really bad and error prone.
-            // TODO: Remove when min PHP version is 8.5
-            $pos = \strpos($htu, '?');
+        // This parser is really bad and error prone.
+        // TODO: Remove when min PHP version is 8.5
+        $pos = \strpos($htu, '?');
+        if ($pos !== false) {
+            $htu = \substr($htu, 0, $pos);
+        } else {
+            $pos = \strpos($htu, '#');
             if ($pos !== false) {
                 $htu = \substr($htu, 0, $pos);
-            } else {
-                $pos = \strpos($htu, '#');
-                if ($pos !== false) {
-                    $htu = \substr($htu, 0, $pos);
-                }
             }
         }
 


### PR DESCRIPTION
I am trying to use this plugin as part of a WordPress plugin, which only supports PHP 8.4 in beta right now. Nothing in this codebase explicitly requires 8.4, and the tests still pass on 8.3.

This PR changes the workflows to run tests on 8.3, and reduces the minimum version in `composer.json` to 8.3. A couple formatting changes were needed as well, but nothing functional.